### PR TITLE
! and @license tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const write = function(file, pkg, customTemplate, cb) {
 `/*!
  * @license
  * ${pkg.name} v${pkg.version} ${pkg.homepage ? '(' + pkg.homepage + ')' : ''}
- * Copyright ${(new Date()).getFullYear()} ${pkg.author ? (typeof pkg.author === 'string' ? pkg.author : (pkg.author.name || '')) : ''} ${pkg.author && pkg.author.url ? '(' + pkg.author.url + ')' : ''}
+ * Copyright ${(new Date()).getFullYear()} ${pkg.author ? (typeof pkg.author === 'string' ? pkg.author : (pkg.author.name || '')) : ''}${pkg.author && pkg.author.url ? ' (' + pkg.author.url + ')' : ''}
 ${pkg.license ? ' * Licensed under ' + pkg.license + `\n */` : ` */`}
 `) + file.contents);
   cb(null, file);

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ const Promise = require('pinkie-promise');
 
 const write = function(file, pkg, customTemplate, cb) {
   file.contents = new Buffer((typeof customTemplate === 'string' ? customTemplate :
-`/**
+`/*!
+ * @license
  * ${pkg.name} v${pkg.version} ${pkg.homepage ? '(' + pkg.homepage + ')' : ''}
  * Copyright ${(new Date()).getFullYear()} ${pkg.author ? (typeof pkg.author === 'string' ? pkg.author : (pkg.author.name || '')) : ''} ${pkg.author && pkg.author.url ? '(' + pkg.author.url + ')' : ''}
 ${pkg.license ? ' * Licensed under ' + pkg.license + `\n */` : ` */`}


### PR DESCRIPTION
Adds tags to guide other tools like closure compiler or uglify to keep the module header comments.

http://usejsdoc.org/tags-license.html
https://developers.google.com/closure/compiler/faq#license
https://github.com/mishoo/UglifyJS2#usage

Also fixed extra space that was added to the end of author line if author url is empty
